### PR TITLE
modify session.execute() output and update user example

### DIFF
--- a/go/client_test.go
+++ b/go/client_test.go
@@ -79,20 +79,20 @@ func TestConnection(t *testing.T) {
 		return
 	}
 
-	checkResp(t, "show hosts", resp)
+	checkConResp(t, "show hosts", resp)
 
 	resp, err = conn.execute(sessionID, "CREATE SPACE client_test(partition_num=1024, replica_factor=1);")
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
-	checkResp(t, "create space", resp)
+	checkConResp(t, "create space", resp)
 	resp, err = conn.execute(sessionID, "DROP SPACE client_test;")
 	if err != nil {
 		t.Error(err.Error())
 		return
 	}
-	checkResp(t, "drop space", resp)
+	checkConResp(t, "drop space", resp)
 
 	res := conn.ping()
 	if res != true {
@@ -155,21 +155,21 @@ func TestPool_SingleHost(t *testing.T) {
 		t.Fatalf(err.Error())
 		return
 	}
-	checkResp(t, "show hosts", resp)
+	checkResSetResp(t, "show hosts", resp)
 	// Create a new space
 	resp, err = session.Execute("CREATE SPACE client_test(partition_num=1024, replica_factor=1);")
 	if err != nil {
 		t.Fatalf(err.Error())
 		return
 	}
-	checkResp(t, "create space", resp)
+	checkResSetResp(t, "create space", resp)
 
 	resp, err = session.Execute("DROP SPACE client_test;")
 	if err != nil {
 		t.Fatalf(err.Error())
 		return
 	}
-	checkResp(t, "drop space", resp)
+	checkResSetResp(t, "drop space", resp)
 }
 
 func TestPool_MultiHosts(t *testing.T) {
@@ -224,7 +224,7 @@ func TestPool_MultiHosts(t *testing.T) {
 		t.Fatalf(err.Error())
 		return
 	}
-	checkResp(t, "show hosts", resp)
+	checkResSetResp(t, "show hosts", resp)
 
 	// Try to get more session when the pool is full
 	newSession, err = pool.GetSession(username, password)
@@ -399,9 +399,14 @@ func TestIpLookup(t *testing.T) {
 }
 
 // Method used to check execution response
-func checkResp(t *testing.T, prefix string, err *graph.ExecutionResponse) {
-	if IsError(err) {
+func checkResSetResp(t *testing.T, prefix string, err *ResultSet) {
+	if !err.IsSucceed() {
 		t.Errorf("%s, ErrorCode: %v, ErrorMsg: %s", prefix, err.GetErrorCode(), err.GetErrorMsg())
+	}
+}
+func checkConResp(t *testing.T, prefix string, err *graph.ExecutionResponse) {
+	if IsError(err) {
+		t.Errorf("%s, ErrorCode: %v, ErrorMsg: %s", prefix, err.ErrorCode, err.ErrorMsg)
 	}
 }
 

--- a/go/client_test.go
+++ b/go/client_test.go
@@ -378,7 +378,7 @@ func TestReconnect(t *testing.T) {
 	}
 
 	// This assertion will pass only when reconnection happens
-	assert.Equal(t, resp.GetErrorCode(), graph.ErrorCode_E_SESSION_INVALID, "Expected error should be E_SESSION_INVALID")
+	assert.Equal(t, ErrorCode_E_SESSION_INVALID, resp.GetErrorCode(), "Expected error should be E_SESSION_INVALID")
 
 	startContainer(t, "nebula-docker-compose_graphd_1")
 	startContainer(t, "nebula-docker-compose_graphd2_1")

--- a/go/example/graph_client_example.go
+++ b/go/example/graph_client_example.go
@@ -131,22 +131,23 @@ func main() {
 			record.PrintRow()
 			fmt.Print("\n")
 			// Get a value in the row by column index
-			v1, err := record.GetValueByIndex(0)
+			valueWrapper, err := record.GetValueByIndex(0)
 			if err != nil {
 				log.Error(err.Error())
 			}
 			// Get type of the value
-			v1Type := v1.GetType()
-			fmt.Printf("v1 type: %s \n", v1Type)
-			// Check if v1 is a tring type
-			if v1.IsString() {
-				// Convert v1 to a string value
-				v1Str, err := v1.AsString()
+			fmt.Printf("valueWrapper type: %s \n", valueWrapper.GetType())
+			// Check if valueWrapper is a string type
+			if valueWrapper.IsString() {
+				// Convert valueWrapper to a string value
+				v1Str, err := valueWrapper.AsString()
 				if err != nil {
 					log.Error(err.Error())
 				}
-				fmt.Print(v1Str)
+				fmt.Printf("Result of ValueWrapper.AsString(): %s\n", v1Str)
 			}
+			// Print ValueWrapper using String()
+			fmt.Printf("Print using ValueWrapper.String(): %s", valueWrapper.String())
 		}
 	}(&wg)
 	wg.Wait()

--- a/go/example/graph_client_example.go
+++ b/go/example/graph_client_example.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -117,9 +118,7 @@ func main() {
 
 			// Get all column names from the resultSet
 			colNames := resultSet.GetColNames()
-			for _, name := range colNames {
-				fmt.Printf("%15s |", name)
-			}
+			fmt.Printf("column names: " + strings.Join(colNames, ", "))
 			fmt.Print("\n")
 
 			// Get a row from resultSet
@@ -128,6 +127,7 @@ func main() {
 				log.Error(err.Error())
 			}
 			// Print whole row
+			fmt.Print("row elements: ")
 			record.PrintRow()
 			fmt.Print("\n")
 			// Get a value in the row by column index

--- a/go/logger.go
+++ b/go/logger.go
@@ -20,17 +20,17 @@ type Logger interface {
 type DefaultLogger struct{}
 
 func (l DefaultLogger) Info(msg string) {
-	log.Printf("[INFO] %s", msg)
+	log.Printf("\n[INFO] %s", msg)
 }
 
 func (l DefaultLogger) Warn(msg string) {
-	log.Printf("[WARNING] %s", msg)
+	log.Printf("\n[WARNING] %s", msg)
 }
 
 func (l DefaultLogger) Error(msg string) {
-	log.Printf("[ERROR] %s", msg)
+	log.Printf("\n[ERROR] %s", msg)
 }
 
 func (l DefaultLogger) Fatal(msg string) {
-	log.Fatalf("[FATAL] %s", msg)
+	log.Fatalf("\n[FATAL] %s", msg)
 }

--- a/go/logger.go
+++ b/go/logger.go
@@ -20,17 +20,17 @@ type Logger interface {
 type DefaultLogger struct{}
 
 func (l DefaultLogger) Info(msg string) {
-	log.Printf("\n[INFO] %s", msg)
+	log.Printf("[INFO] %s\n", msg)
 }
 
 func (l DefaultLogger) Warn(msg string) {
-	log.Printf("\n[WARNING] %s", msg)
+	log.Printf("[WARNING] %s\n", msg)
 }
 
 func (l DefaultLogger) Error(msg string) {
-	log.Printf("\n[ERROR] %s", msg)
+	log.Printf("[ERROR] %s\n", msg)
 }
 
 func (l DefaultLogger) Fatal(msg string) {
-	log.Fatalf("\n[FATAL] %s", msg)
+	log.Fatalf("[FATAL] %s\n", msg)
 }

--- a/go/result_set.go
+++ b/go/result_set.go
@@ -47,25 +47,24 @@ type PathWrapper struct {
 	segments         []segment
 }
 
-func genResultSet(resp graph.ExecutionResponse) *ResultSet {
+func genResultSet(resp *graph.ExecutionResponse) *ResultSet {
 	var colNames []string
 	var colNameIndexMap = make(map[string]int)
 
 	if resp.Data == nil || resp.Data.ColumnNames == nil || resp.Data.Rows == nil {
 		return &ResultSet{
-			resp:            &resp,
+			resp:            resp,
 			columnNames:     colNames,
 			colNameIndexMap: colNameIndexMap,
 		}
 	}
-
 	for i, name := range resp.Data.ColumnNames {
 		colNames = append(colNames, string(name))
 		colNameIndexMap[string(name)] = i
 	}
 
 	return &ResultSet{
-		resp:            &resp,
+		resp:            resp,
 		columnNames:     colNames,
 		colNameIndexMap: colNameIndexMap,
 	}
@@ -212,10 +211,6 @@ func (res ResultSet) GetRowValuesByIndex(index int) (*Record, error) {
 
 // Returns all rows
 func (res ResultSet) GetRows() []*nebula.Row {
-	if res.resp.Data == nil || res.resp.Data.Rows == nil {
-		var empty []*nebula.Row
-		return empty
-	}
 	return res.resp.Data.Rows
 }
 
@@ -228,10 +223,6 @@ func (res ResultSet) GetErrorCode() graph.ErrorCode {
 }
 
 func (res ResultSet) GetErrorMsg() []byte {
-	if res.resp.ErrorMsg == nil {
-		var empty []byte
-		return empty
-	}
 	return res.resp.ErrorMsg
 }
 
@@ -262,6 +253,12 @@ func (record Record) GetValueByColName(colName string) (*ValueWrapper, error) {
 	// Get index
 	index := (*record.colNameIndexMap)[colName]
 	return record._record[index], nil
+}
+
+func (record Record) PrintRow() {
+	for _, val := range record._record {
+		val.printValue()
+	}
 }
 
 func (record Record) hasColName(colName string) bool {

--- a/go/result_set.go
+++ b/go/result_set.go
@@ -49,6 +49,24 @@ type PathWrapper struct {
 	segments         []segment
 }
 
+type ErrorCode int64
+
+const (
+	ErrorCode_SUCCEEDED               ErrorCode = ErrorCode(graph.ErrorCode_SUCCEEDED)
+	ErrorCode_E_DISCONNECTED          ErrorCode = ErrorCode(graph.ErrorCode_E_DISCONNECTED)
+	ErrorCode_E_FAIL_TO_CONNECT       ErrorCode = ErrorCode(graph.ErrorCode_E_FAIL_TO_CONNECT)
+	ErrorCode_E_RPC_FAILURE           ErrorCode = ErrorCode(graph.ErrorCode_E_RPC_FAILURE)
+	ErrorCode_E_BAD_USERNAME_PASSWORD ErrorCode = ErrorCode(graph.ErrorCode_E_BAD_USERNAME_PASSWORD)
+	ErrorCode_E_SESSION_INVALID       ErrorCode = ErrorCode(graph.ErrorCode_E_SESSION_INVALID)
+	ErrorCode_E_SESSION_TIMEOUT       ErrorCode = ErrorCode(graph.ErrorCode_E_SESSION_TIMEOUT)
+	ErrorCode_E_SYNTAX_ERROR          ErrorCode = ErrorCode(graph.ErrorCode_E_SYNTAX_ERROR)
+	ErrorCode_E_EXECUTION_ERROR       ErrorCode = ErrorCode(graph.ErrorCode_E_EXECUTION_ERROR)
+	ErrorCode_E_STATEMENT_EMTPY       ErrorCode = ErrorCode(graph.ErrorCode_E_STATEMENT_EMTPY)
+	ErrorCode_E_USER_NOT_FOUND        ErrorCode = ErrorCode(graph.ErrorCode_E_USER_NOT_FOUND)
+	ErrorCode_E_BAD_PERMISSION        ErrorCode = ErrorCode(graph.ErrorCode_E_BAD_PERMISSION)
+	ErrorCode_E_SEMANTIC_ERROR        ErrorCode = ErrorCode(graph.ErrorCode_E_SEMANTIC_ERROR)
+)
+
 func genResultSet(resp *graph.ExecutionResponse) *ResultSet {
 	var colNames []string
 	var colNameIndexMap = make(map[string]int)

--- a/go/result_set.go
+++ b/go/result_set.go
@@ -257,7 +257,7 @@ func (record Record) GetValueByColName(colName string) (*ValueWrapper, error) {
 
 func (record Record) PrintRow() {
 	for _, val := range record._record {
-		val.printValue()
+		fmt.Printf("%15s |", val.String())
 	}
 }
 

--- a/go/result_set.go
+++ b/go/result_set.go
@@ -232,8 +232,22 @@ func (res ResultSet) GetColNames() []string {
 	return res.columnNames
 }
 
-func (res ResultSet) GetErrorCode() graph.ErrorCode {
-	return res.resp.ErrorCode
+// Returns an integer representing an error type
+// 0    ErrorCode_SUCCEEDED
+// -1   ErrorCode_E_DISCONNECTED
+// -2   ErrorCode_E_FAIL_TO_CONNECT
+// -3   ErrorCode_E_RPC_FAILURE
+// -4   ErrorCode_E_BAD_USERNAME_PASSWORD
+// -5   ErrorCode_E_SESSION_INVALID
+// -6   ErrorCode_E_SESSION_TIMEOUT
+// -7   ErrorCode_E_SYNTAX_ERROR
+// -8   ErrorCode_E_EXECUTION_ERROR
+// -9   ErrorCode_E_STATEMENT_EMTPY
+// -10  ErrorCode_E_USER_NOT_FOUND
+// -11  ErrorCode_E_BAD_PERMISSION
+// -12  ErrorCode_E_SEMANTIC_ERROR
+func (res ResultSet) GetErrorCode() ErrorCode {
+	return ErrorCode(int64(res.resp.ErrorCode))
 }
 
 func (res ResultSet) GetErrorMsg() []byte {
@@ -245,7 +259,7 @@ func (res ResultSet) GetErrorMsg() []byte {
 }
 
 func (res ResultSet) IsSucceed() bool {
-	return res.GetErrorCode() == graph.ErrorCode_SUCCEEDED
+	return res.GetErrorCode() == ErrorCode_SUCCEEDED
 }
 
 func (res ResultSet) hasColName(colName string) bool {

--- a/go/result_set.go
+++ b/go/result_set.go
@@ -211,6 +211,10 @@ func (res ResultSet) GetRowValuesByIndex(index int) (*Record, error) {
 
 // Returns all rows
 func (res ResultSet) GetRows() []*nebula.Row {
+	if res.resp.Data == nil || res.resp.Data.Rows == nil {
+		var empty []*nebula.Row
+		return empty
+	}
 	return res.resp.Data.Rows
 }
 
@@ -223,6 +227,10 @@ func (res ResultSet) GetErrorCode() graph.ErrorCode {
 }
 
 func (res ResultSet) GetErrorMsg() []byte {
+	if res.resp.ErrorMsg == nil {
+		var empty []byte
+		return empty
+	}
 	return res.resp.ErrorMsg
 }
 

--- a/go/result_set.go
+++ b/go/result_set.go
@@ -7,6 +7,7 @@
 package nebula
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/vesoft-inc/nebula-clients/go/nebula"
@@ -177,6 +178,14 @@ func genPathWrapper(path *nebula.Path) (*PathWrapper, error) {
 		relationshipList: relationshipList,
 		segments:         segList,
 	}, nil
+}
+
+/*
+Returns ExecutionResponse as a JSON []byte.
+To get the string value in the nested JSON struct, decode with base64
+*/
+func (res ResultSet) MarshalJSON() ([]byte, error) {
+	return json.Marshal(res.resp.Data)
 }
 
 // Returns all values in the given column

--- a/go/result_set.go
+++ b/go/result_set.go
@@ -9,6 +9,7 @@ package nebula
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/vesoft-inc/nebula-clients/go/nebula"
 	"github.com/vesoft-inc/nebula-clients/go/nebula/graph"
@@ -273,9 +274,11 @@ func (record Record) GetValueByColName(colName string) (*ValueWrapper, error) {
 }
 
 func (record Record) PrintRow() {
+	var strList []string
 	for _, val := range record._record {
-		fmt.Printf("%15s |", val.String())
+		strList = append(strList, val.String())
 	}
+	fmt.Printf(strings.Join(strList, ", "))
 }
 
 func (record Record) hasColName(colName string) bool {
@@ -346,15 +349,6 @@ func (node Node) Values(tagName string) ([]*ValueWrapper, error) {
 // Returns true if two nodes have same vid
 func (n1 Node) IsEqualTo(n2 *Node) bool {
 	return n1.GetID() == n2.GetID()
-}
-
-func (node Node) getTagIndexbyName(tagName string) (int, error) {
-	for index, label := range node.tags {
-		if label == tagName {
-			return index, nil
-		}
-	}
-	return -1, fmt.Errorf("Failed to get index: Tag name %s does not exsist in the Node", tagName)
 }
 
 func (relationship Relationship) GetSrcVertexID() string {

--- a/go/result_set_test.go
+++ b/go/result_set_test.go
@@ -75,7 +75,7 @@ func TestAsString(t *testing.T) {
 	value := nebula.Value{SVal: []byte(val)}
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsString())
-	assert.Equal(t, "test_string", valWrap.String())
+	assert.Equal(t, "\"test_string\"", valWrap.String())
 	res, _ := valWrap.AsString()
 	assert.Equal(t, string(value.GetSVal()), res)
 }
@@ -90,7 +90,7 @@ func TestAsList(t *testing.T) {
 		LVal: &nebula.List{Values: valList},
 	}
 	valWrap := ValueWrapper{&value}
-	assert.Equal(t, "[elem1, elem2, elem3]", valWrap.String())
+	assert.Equal(t, "[\"elem1\", \"elem2\", \"elem3\"]", valWrap.String())
 	assert.Equal(t, true, valWrap.IsList())
 
 	res, _ := valWrap.AsList()
@@ -113,7 +113,7 @@ func TestAsDedupList(t *testing.T) {
 		UVal: &nebula.Set{Values: valList},
 	}
 	valWrap := ValueWrapper{&value}
-	assert.Equal(t, "[elem1, elem2, elem3]", valWrap.String())
+	assert.Equal(t, "[\"elem1\", \"elem2\", \"elem3\"]", valWrap.String())
 	assert.Equal(t, true, valWrap.IsSet())
 
 	res, _ := valWrap.AsList()
@@ -136,7 +136,7 @@ func TestAsMap(t *testing.T) {
 	mval := nebula.Map{Kvs: valueMap}
 	value := nebula.Value{MVal: &mval}
 	valWrap := ValueWrapper{&value}
-	assert.Equal(t, "{key0: val0, key1: val1, key2: val2}", valWrap.String())
+	assert.Equal(t, "{key0: \"val0\", key1: \"val1\", key2: \"val2\"}", valWrap.String())
 	assert.Equal(t, true, valWrap.IsMap())
 	vMap := value.GetMVal().Kvs
 	valWrapMap, err := valWrap.AsMap()
@@ -156,9 +156,9 @@ func TestAsNode(t *testing.T) {
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsVertex())
 	assert.Equal(t,
-		"[Adam: {tag0:{[prop0: 0], [prop1: 1], [prop2: 2], [prop3: 3], [prop4: 4]}, "+
-			"tag1:{[prop0: 0], [prop1: 1], [prop2: 2], [prop3: 3], [prop4: 4]}, "+
-			"tag2:{[prop0: 0], [prop1: 1], [prop2: 2], [prop3: 3], [prop4: 4]}}]",
+		"[Adam: {tag0:{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}, "+
+			"tag1:{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}, "+
+			"tag2:{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}}]",
 		valWrap.String())
 	res, _ := valWrap.AsNode()
 	node, _ := genNode(value.GetVVal())
@@ -169,7 +169,7 @@ func TestAsRelationship(t *testing.T) {
 	value := nebula.Value{EVal: getEdge("Alice", "Bob")}
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsEdge())
-	assert.Equal(t, "(Alice)-[classmate:1@100 {[prop0: 0], [prop1: 1], [prop2: 2], [prop3: 3], [prop4: 4]}]->(Bob)", valWrap.String())
+	assert.Equal(t, "(\"Alice\")-[classmate]->(\"Bob\")@100{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}", valWrap.String())
 	res, _ := valWrap.AsRelationship()
 	relationship, _ := genRelationship(value.GetEVal())
 	assert.Equal(t, *relationship, *res)
@@ -180,7 +180,7 @@ func TestAsPathWrapper(t *testing.T) {
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsPath())
 	assert.Equal(t,
-		"Alice-[classmate:1@100]->vertex0-[classmate:-1@100]<-vertex1-[classmate:1@100]->vertex2-[classmate:-1@100]<-vertex3-[classmate:1@100]->vertex4",
+		"(Alice)-[classmate@100]->(vertex0)<-[classmate@100]-(vertex1)-[classmate@100]->(vertex2)<-[classmate@100]-(vertex3)-[classmate@100]->(vertex4)",
 		valWrap.String())
 
 	res, _ := valWrap.AsPath()

--- a/go/result_set_test.go
+++ b/go/result_set_test.go
@@ -336,6 +336,8 @@ func TestResultSet(t *testing.T) {
 	resultSet := genResultSet(resp)
 
 	assert.Equal(t, graph.ErrorCode_SUCCEEDED, resultSet.GetErrorCode())
+	assert.Equal(t, "test_space", string(resultSet.resp.SpaceName))
+	assert.Equal(t, "test_comment", string(resultSet.resp.Comment))
 	assert.Equal(t, true, resultSet.IsSucceed())
 
 	expectedColNames := []string{"col0_int", "col1_string", "col2_vertex", "col3_edge", "col4_path"}
@@ -380,6 +382,23 @@ func TestResultSet(t *testing.T) {
 	assert.Equal(t, v3.GetID(), expected_v3.GetID())
 	assert.Equal(t, true, v4.IsEqualTo(expected_v4))
 	assert.Equal(t, true, v5.IsEqualTo(expected_v5))
+}
+
+func TestMarshalJson(t *testing.T) {
+	resp := &graph.ExecutionResponse{
+		graph.ErrorCode_SUCCEEDED,
+		1000,
+		getDateset(),
+		[]byte("test_space"),
+		[]byte("test"),
+		graph.NewPlanDescription(),
+		[]byte("test_comment")}
+	resultSet := genResultSet(resp)
+
+	_, err := resultSet.MarshalJSON()
+	if err != nil {
+		t.Error(err.Error())
+	}
 }
 
 func getVertex(vid string) *nebula.Vertex {

--- a/go/result_set_test.go
+++ b/go/result_set_test.go
@@ -136,7 +136,7 @@ func TestAsMap(t *testing.T) {
 	mval := nebula.Map{Kvs: valueMap}
 	value := nebula.Value{MVal: &mval}
 	valWrap := ValueWrapper{&value}
-	assert.Equal(t, "{key0: \"val0\", key1: \"val1\", key2: \"val2\"}", valWrap.String())
+	assert.Equal(t, "{\"key0\": \"val0\", \"key1\": \"val1\", \"key2\": \"val2\"}", valWrap.String())
 	assert.Equal(t, true, valWrap.IsMap())
 	vMap := value.GetMVal().Kvs
 	valWrapMap, err := valWrap.AsMap()
@@ -151,14 +151,35 @@ func TestAsMap(t *testing.T) {
 }
 
 // TODO: add tests for AsTime/Date/DateTime when service supports timezone
+func TestAsDate(t *testing.T) {
+	value := nebula.Value{DVal: &nebula.Date{2020, 12, 25}}
+	valWrap := ValueWrapper{&value}
+	assert.Equal(t, true, valWrap.IsDate())
+	assert.Equal(t, "2020-12-25", valWrap.String())
+}
+
+func TestAsTime(t *testing.T) {
+	value := nebula.Value{TVal: &nebula.Time{13, 12, 25, 29}}
+	valWrap := ValueWrapper{&value}
+	assert.Equal(t, true, valWrap.IsTime())
+	assert.Equal(t, "13:12:25.29", valWrap.String())
+}
+
+func TestAsDateTime(t *testing.T) {
+	value := nebula.Value{DtVal: &nebula.DateTime{2020, 12, 25, 13, 12, 25, 29}}
+	valWrap := ValueWrapper{&value}
+	assert.Equal(t, true, valWrap.IsDateTime())
+	assert.Equal(t, "2020-12-25T13:12:25.29", valWrap.String())
+}
+
 func TestAsNode(t *testing.T) {
 	value := nebula.Value{VVal: getVertex("Adam")}
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsVertex())
 	assert.Equal(t,
-		"[Adam: {tag0:{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}, "+
-			"tag1:{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}, "+
-			"tag2:{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}}]",
+		"[Adam: {tag0:{\"prop0\": 0, \"prop1\": 1, \"prop2\": 2, \"prop3\": 3, \"prop4\": 4}, "+
+			"tag1:{\"prop0\": 0, \"prop1\": 1, \"prop2\": 2, \"prop3\": 3, \"prop4\": 4}, "+
+			"tag2:{\"prop0\": 0, \"prop1\": 1, \"prop2\": 2, \"prop3\": 3, \"prop4\": 4}}]",
 		valWrap.String())
 	res, _ := valWrap.AsNode()
 	node, _ := genNode(value.GetVVal())
@@ -169,7 +190,7 @@ func TestAsRelationship(t *testing.T) {
 	value := nebula.Value{EVal: getEdge("Alice", "Bob")}
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsEdge())
-	assert.Equal(t, "(\"Alice\")-[classmate]->(\"Bob\")@100{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}", valWrap.String())
+	assert.Equal(t, "(\"Alice\")-[classmate]->(\"Bob\")@100{\"prop0\": 0, \"prop1\": 1, \"prop2\": 2, \"prop3\": 3, \"prop4\": 4}", valWrap.String())
 	res, _ := valWrap.AsRelationship()
 	relationship, _ := genRelationship(value.GetEVal())
 	assert.Equal(t, *relationship, *res)

--- a/go/result_set_test.go
+++ b/go/result_set_test.go
@@ -162,14 +162,14 @@ func TestAsTime(t *testing.T) {
 	value := nebula.Value{TVal: &nebula.Time{13, 12, 25, 29}}
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsTime())
-	assert.Equal(t, "13:12:25.29", valWrap.String())
+	assert.Equal(t, "13:12:25.029", valWrap.String())
 }
 
 func TestAsDateTime(t *testing.T) {
 	value := nebula.Value{DtVal: &nebula.DateTime{2020, 12, 25, 13, 12, 25, 29}}
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsDateTime())
-	assert.Equal(t, "2020-12-25T13:12:25.29", valWrap.String())
+	assert.Equal(t, "2020-12-25T13:12:25.029", valWrap.String())
 }
 
 func TestAsNode(t *testing.T) {

--- a/go/result_set_test.go
+++ b/go/result_set_test.go
@@ -136,7 +136,7 @@ func TestAsMap(t *testing.T) {
 	mval := nebula.Map{Kvs: valueMap}
 	value := nebula.Value{MVal: &mval}
 	valWrap := ValueWrapper{&value}
-	assert.Equal(t, "{\"key0\": \"val0\", \"key1\": \"val1\", \"key2\": \"val2\"}", valWrap.String())
+	assert.Equal(t, "{key0: \"val0\", key1: \"val1\", key2: \"val2\"}", valWrap.String())
 	assert.Equal(t, true, valWrap.IsMap())
 	vMap := value.GetMVal().Kvs
 	valWrapMap, err := valWrap.AsMap()
@@ -177,9 +177,9 @@ func TestAsNode(t *testing.T) {
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsVertex())
 	assert.Equal(t,
-		"[Adam: {tag0:{\"prop0\": 0, \"prop1\": 1, \"prop2\": 2, \"prop3\": 3, \"prop4\": 4}, "+
-			"tag1:{\"prop0\": 0, \"prop1\": 1, \"prop2\": 2, \"prop3\": 3, \"prop4\": 4}, "+
-			"tag2:{\"prop0\": 0, \"prop1\": 1, \"prop2\": 2, \"prop3\": 3, \"prop4\": 4}}]",
+		"(\"Adam\" :tag0{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4} "+
+			":tag1{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4} "+
+			":tag2{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4})",
 		valWrap.String())
 	res, _ := valWrap.AsNode()
 	node, _ := genNode(value.GetVVal())
@@ -190,20 +190,19 @@ func TestAsRelationship(t *testing.T) {
 	value := nebula.Value{EVal: getEdge("Alice", "Bob")}
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsEdge())
-	assert.Equal(t, "(\"Alice\")-[classmate]->(\"Bob\")@100{\"prop0\": 0, \"prop1\": 1, \"prop2\": 2, \"prop3\": 3, \"prop4\": 4}", valWrap.String())
+	assert.Equal(t, "(\"Alice\")-[:classmate@100{prop0: 0, prop1: 1, prop2: 2, prop3: 3, prop4: 4}]->(\"Bob\")", valWrap.String())
 	res, _ := valWrap.AsRelationship()
 	relationship, _ := genRelationship(value.GetEVal())
 	assert.Equal(t, *relationship, *res)
 }
 
-func TestAsPathWrapper(t *testing.T) {
+func TestAsPathWrapper(t *testing.T) { //("Tim Duncan")-[:serve@0]->("Spurs")<-[:serve@0]-("Tony Parker")
 	value := nebula.Value{PVal: getPath("Alice", 5)}
 	valWrap := ValueWrapper{&value}
 	assert.Equal(t, true, valWrap.IsPath())
 	assert.Equal(t,
-		"(Alice)-[classmate@100]->(vertex0)<-[classmate@100]-(vertex1)-[classmate@100]->(vertex2)<-[classmate@100]-(vertex3)-[classmate@100]->(vertex4)",
+		"(\"Alice\")-[:classmate@100]->(\"vertex0\")<-[:classmate@100]-(\"vertex1\")-[:classmate@100]->(\"vertex2\")<-[:classmate@100]-(\"vertex3\")-[:classmate@100]->(\"vertex4\")",
 		valWrap.String())
-
 	res, _ := valWrap.AsPath()
 	path, _ := genPathWrapper(value.GetPVal())
 	assert.Equal(t, *path, *res)

--- a/go/result_set_test.go
+++ b/go/result_set_test.go
@@ -236,7 +236,7 @@ func TestPathWrapper(t *testing.T) {
 }
 
 func TestResultSet(t *testing.T) {
-	resp := graph.ExecutionResponse{
+	resp := &graph.ExecutionResponse{
 		graph.ErrorCode_SUCCEEDED,
 		1000,
 		getDateset(),

--- a/go/result_set_test.go
+++ b/go/result_set_test.go
@@ -335,7 +335,7 @@ func TestResultSet(t *testing.T) {
 		[]byte("test_comment")}
 	resultSet := genResultSet(resp)
 
-	assert.Equal(t, graph.ErrorCode_SUCCEEDED, resultSet.GetErrorCode())
+	assert.Equal(t, ErrorCode_SUCCEEDED, resultSet.GetErrorCode())
 	assert.Equal(t, "test_space", string(resultSet.resp.SpaceName))
 	assert.Equal(t, "test_comment", string(resultSet.resp.Comment))
 	assert.Equal(t, true, resultSet.IsSucceed())

--- a/go/session.go
+++ b/go/session.go
@@ -25,14 +25,14 @@ type Session struct {
 // 	return session.graph.ExecuteJson(session.sessionID, []byte(stmt))
 // }
 
-// Execute a query
-func (session *Session) Execute(stmt string) (*graph.ExecutionResponse, error) {
+// Execute() returns the result of given query as a ResultSet
+func (session *Session) Execute(stmt string) (*ResultSet, error) {
 	if session.connection == nil {
 		return nil, fmt.Errorf("Faied to execute: Session has been released")
 	}
 	resp, err := session.connection.execute(session.sessionID, stmt)
 	if err == nil {
-		return resp, nil
+		return genResultSet(resp), nil
 	}
 	// Reconnect only if the tranport is closed
 	if err, ok := err.(thrift.TransportException); ok && err.TypeID() == thrift.END_OF_FILE {
@@ -48,11 +48,11 @@ func (session *Session) Execute(stmt string) (*graph.ExecutionResponse, error) {
 		if err != nil {
 			return nil, err
 		}
-		return resp, nil
+		return genResultSet(resp), nil
 	}
 	// Reconnect fail
 	session.log.Error(fmt.Sprintf("Error info: %s", err.Error()))
-	return resp, err
+	return genResultSet(resp), err
 }
 
 func (session *Session) reConnect() error {

--- a/go/session.go
+++ b/go/session.go
@@ -38,10 +38,10 @@ func (session *Session) Execute(stmt string) (*ResultSet, error) {
 	if err, ok := err.(thrift.TransportException); ok && err.TypeID() == thrift.END_OF_FILE {
 		_err := session.reConnect()
 		if _err != nil {
-			session.log.Error(fmt.Sprintf("Failed to reconnect, %s \n", _err.Error()))
+			session.log.Error(fmt.Sprintf("Failed to reconnect, %s", _err.Error()))
 			return nil, _err
 		}
-		session.log.Info(fmt.Sprintf("Successfully reconnect to host: %s, port: %d \n",
+		session.log.Info(fmt.Sprintf("Successfully reconnect to host: %s, port: %d",
 			session.connection.severAddress.Host, session.connection.severAddress.Port))
 		// Execute with the new connetion
 		resp, err := session.connection.execute(session.sessionID, stmt)

--- a/go/value_wrapper.go
+++ b/go/value_wrapper.go
@@ -266,12 +266,17 @@ func (valWarp ValueWrapper) String() string {
 		return fStr
 	} else if value.IsSetSVal() {
 		return `"` + string(value.GetSVal()) + `"`
-	} else if value.IsSetDVal() {
-		return value.GetDVal().String()
-	} else if value.IsSetTVal() {
-		return value.GetTVal().String()
-	} else if value.IsSetDtVal() {
-		return value.GetDtVal().String()
+	} else if value.IsSetDVal() { // Date yyyy-mm-dd
+		date := value.GetDVal()
+		return fmt.Sprintf("%d-%d-%d", date.Year, date.Month, date.Day)
+	} else if value.IsSetTVal() { // Time HH:MM:SS.MS
+		time := value.GetTVal()
+		return fmt.Sprintf("%d:%d:%d.%d", time.Hour, time.Minute, time.Sec, time.Microsec)
+	} else if value.IsSetDtVal() { // DateTime yyyy-mm-ddTHH:MM:SS.MS  TODO: add time zone
+		dateTime := value.GetDtVal()
+		return fmt.Sprintf("%d-%d-%dT%d:%d:%d.%d",
+			dateTime.Year, dateTime.Month, dateTime.Day,
+			dateTime.Hour, dateTime.Minute, dateTime.Sec, dateTime.Microsec)
 	} else if value.IsSetVVal() { // Vertex (vid: tagName{propKey: propVal, propKey2, propVal2})
 		var keyList []string
 		var kvStr []string
@@ -286,7 +291,7 @@ func (valWarp ValueWrapper) String() string {
 			}
 			sort.Strings(keyList)
 			for _, k := range keyList {
-				kvTemp := fmt.Sprintf("%s: %s", k, ValueWrapper{kvs[k]}.String())
+				kvTemp := fmt.Sprintf("\"%s\": %s", k, ValueWrapper{kvs[k]}.String())
 				kvStr = append(kvStr, kvTemp)
 			}
 			tagStr = append(tagStr, fmt.Sprintf("%s:{%s}", tagName, strings.Join(kvStr, ", ")))
@@ -303,7 +308,7 @@ func (valWarp ValueWrapper) String() string {
 		}
 		sort.Strings(keyList)
 		for _, k := range keyList {
-			kvTemp := fmt.Sprintf("%s: %s", k, ValueWrapper{edge.Props[k]}.String())
+			kvTemp := fmt.Sprintf("\"%s\": %s", k, ValueWrapper{edge.Props[k]}.String())
 			kvStr = append(kvStr, kvTemp)
 		}
 		if edge.Type > 0 {
@@ -325,14 +330,14 @@ func (valWarp ValueWrapper) String() string {
 			}
 		}
 		return resStr
-	} else if value.IsSetLVal() {
+	} else if value.IsSetLVal() { // List
 		lval := value.GetLVal()
 		var strs []string
 		for _, val := range lval.Values {
 			strs = append(strs, ValueWrapper{val}.String())
 		}
 		return fmt.Sprintf("[%s]", strings.Join(strs, ", "))
-	} else if value.IsSetMVal() {
+	} else if value.IsSetMVal() { // Map
 		// {k0: v0, k1: v1}
 		mval := value.GetMVal()
 		var keyList []string
@@ -343,7 +348,7 @@ func (valWarp ValueWrapper) String() string {
 		}
 		sort.Strings(keyList)
 		for _, k := range keyList {
-			output = append(output, fmt.Sprintf("%s: %s", k, ValueWrapper{kvs[k]}.String()))
+			output = append(output, fmt.Sprintf("\"%s\": %s", k, ValueWrapper{kvs[k]}.String()))
 		}
 		return fmt.Sprintf("{%s}", strings.Join(output, ", "))
 	} else if value.IsSetUVal() {

--- a/go/value_wrapper.go
+++ b/go/value_wrapper.go
@@ -111,7 +111,7 @@ func (valueWrapper ValueWrapper) AsString() (string, error) {
 	return "", fmt.Errorf("Failed to convert value %s to string", valueWrapper.GetType())
 }
 
-// TODO: Need to wrapper TimeWrapper
+// TODO: Need to wrap TimeWrapper
 func (valueWrapper ValueWrapper) AsTime() (*nebula.Time, error) {
 	if valueWrapper.value.IsSetTVal() {
 		return valueWrapper.value.GetTVal(), nil
@@ -237,4 +237,37 @@ func (valueWrapper ValueWrapper) GetType() string {
 		return "set"
 	}
 	return "empty"
+}
+
+func (valWarp ValueWrapper) printValue() {
+	value := valWarp.value
+	if value.IsSetNVal() {
+		fmt.Printf("%15s |", value.GetNVal().String())
+	} else if value.IsSetBVal() {
+		fmt.Printf("%15t |", value.GetBVal())
+	} else if value.IsSetIVal() {
+		fmt.Printf("%15d |", value.GetIVal())
+	} else if value.IsSetFVal() {
+		fmt.Printf("%15.1f |", value.GetFVal())
+	} else if value.IsSetSVal() {
+		fmt.Printf("%15s |", string(value.GetSVal()))
+	} else if value.IsSetDVal() {
+		fmt.Printf("%15s |", value.GetDVal().String())
+	} else if value.IsSetTVal() {
+		fmt.Printf("%15s |", value.GetTVal().String())
+	} else if value.IsSetDtVal() {
+		fmt.Printf("%15s |", value.GetDtVal().String())
+	} else if value.IsSetVVal() {
+		fmt.Printf("%15s |", value.GetVVal().String())
+	} else if value.IsSetEVal() {
+		fmt.Printf("%15s |", value.GetEVal().String())
+	} else if value.IsSetPVal() {
+		fmt.Printf("%15s |", value.GetPVal().String())
+	} else if value.IsSetLVal() {
+		fmt.Printf("%15s |", value.GetLVal().String())
+	} else if value.IsSetMVal() {
+		fmt.Printf("%15s |", value.GetMVal().String())
+	} else if value.IsSetUVal() {
+		fmt.Printf("%15s |", value.GetUVal().String())
+	}
 }

--- a/go/value_wrapper.go
+++ b/go/value_wrapper.go
@@ -268,13 +268,13 @@ func (valWarp ValueWrapper) String() string {
 		return `"` + string(value.GetSVal()) + `"`
 	} else if value.IsSetDVal() { // Date yyyy-mm-dd
 		date := value.GetDVal()
-		return fmt.Sprintf("%d-%d-%d", date.Year, date.Month, date.Day)
+		return fmt.Sprintf("%d-%02d-%02d", date.Year, date.Month, date.Day)
 	} else if value.IsSetTVal() { // Time HH:MM:SS.MS
 		time := value.GetTVal()
-		return fmt.Sprintf("%d:%d:%d.%d", time.Hour, time.Minute, time.Sec, time.Microsec)
+		return fmt.Sprintf("%02d:%02d:%02d.%03d", time.Hour, time.Minute, time.Sec, time.Microsec)
 	} else if value.IsSetDtVal() { // DateTime yyyy-mm-ddTHH:MM:SS.MS  TODO: add time zone
 		dateTime := value.GetDtVal()
-		return fmt.Sprintf("%d-%d-%dT%d:%d:%d.%d",
+		return fmt.Sprintf("%d-%02d-%02dT%02d:%02d:%02d.%03d",
 			dateTime.Year, dateTime.Month, dateTime.Day,
 			dateTime.Hour, dateTime.Minute, dateTime.Sec, dateTime.Microsec)
 	} else if value.IsSetVVal() { // Vertex format: ("VertexID" :tag1{k0: v0,k1: v1}:tag2{k2: v2})

--- a/go/value_wrapper.go
+++ b/go/value_wrapper.go
@@ -19,6 +19,24 @@ type ValueWrapper struct {
 	value *nebula.Value
 }
 
+type ErrorCode int64
+
+const (
+	ErrorCode_SUCCEEDED               ErrorCode = 0
+	ErrorCode_E_DISCONNECTED          ErrorCode = -1
+	ErrorCode_E_FAIL_TO_CONNECT       ErrorCode = -2
+	ErrorCode_E_RPC_FAILURE           ErrorCode = -3
+	ErrorCode_E_BAD_USERNAME_PASSWORD ErrorCode = -4
+	ErrorCode_E_SESSION_INVALID       ErrorCode = -5
+	ErrorCode_E_SESSION_TIMEOUT       ErrorCode = -6
+	ErrorCode_E_SYNTAX_ERROR          ErrorCode = -7
+	ErrorCode_E_EXECUTION_ERROR       ErrorCode = -8
+	ErrorCode_E_STATEMENT_EMTPY       ErrorCode = -9
+	ErrorCode_E_USER_NOT_FOUND        ErrorCode = -10
+	ErrorCode_E_BAD_PERMISSION        ErrorCode = -11
+	ErrorCode_E_SEMANTIC_ERROR        ErrorCode = -12
+)
+
 func (valueWrapper ValueWrapper) IsEmpty() bool {
 	return valueWrapper.GetType() == "empty"
 }

--- a/go/value_wrapper.go
+++ b/go/value_wrapper.go
@@ -19,24 +19,6 @@ type ValueWrapper struct {
 	value *nebula.Value
 }
 
-type ErrorCode int64
-
-const (
-	ErrorCode_SUCCEEDED               ErrorCode = 0
-	ErrorCode_E_DISCONNECTED          ErrorCode = -1
-	ErrorCode_E_FAIL_TO_CONNECT       ErrorCode = -2
-	ErrorCode_E_RPC_FAILURE           ErrorCode = -3
-	ErrorCode_E_BAD_USERNAME_PASSWORD ErrorCode = -4
-	ErrorCode_E_SESSION_INVALID       ErrorCode = -5
-	ErrorCode_E_SESSION_TIMEOUT       ErrorCode = -6
-	ErrorCode_E_SYNTAX_ERROR          ErrorCode = -7
-	ErrorCode_E_EXECUTION_ERROR       ErrorCode = -8
-	ErrorCode_E_STATEMENT_EMTPY       ErrorCode = -9
-	ErrorCode_E_USER_NOT_FOUND        ErrorCode = -10
-	ErrorCode_E_BAD_PERMISSION        ErrorCode = -11
-	ErrorCode_E_SEMANTIC_ERROR        ErrorCode = -12
-)
-
 func (valueWrapper ValueWrapper) IsEmpty() bool {
 	return valueWrapper.GetType() == "empty"
 }


### PR DESCRIPTION
1. Change the output of session.execute() from ExecutionResponse to ResultSet
2. Update user example
3. Add String() for ValueWrapper and tests
3. Add MarshalJson() for ResultSet. To get the string value in the nested JSON struct, decode with base64

fix:
1. keep vertex/edge/path string format consistent with https://github.com/vesoft-inc/nebula-console/pull/52